### PR TITLE
Convert message accesses to camelcase

### DIFF
--- a/bin/dump-auth-response
+++ b/bin/dump-auth-response
@@ -33,7 +33,7 @@ client.connect(opts, function() {
     var certFilenameDer = 'auth-certificate.der';
 
     fs.writeFileSync(sigFilename, response.signature.toString("binary"), "binary");
-    fs.writeFileSync(certFilenameDer, response.client_auth_certificate.toString("binary"), "binary");
+    fs.writeFileSync(certFilenameDer, response.clientAuthCertificate.toString("binary"), "binary");
 
     var certFilenamePem = 'auth-certificate.pem';
 
@@ -41,8 +41,8 @@ client.connect(opts, function() {
 
     console.log('output written to %s and %s', sigFilename, certFilenamePem);
 
-    for(var i = 0; i < response.client_ca.length; i++) {
-      var ca = response.client_ca[i];
+    for(var i = 0; i < response.clientCa.length; i++) {
+      var ca = response.clientCa[i];
       var ca_name = 'auth-ca' + (i + 1) + '.crt';
 
       fs.writeFileSync(ca_name, ca.toString("binary"), "binary");

--- a/lib/client.js
+++ b/lib/client.js
@@ -64,27 +64,27 @@ Client.prototype.connect = function(options, callback) {
 
     debug(
       'recv message: protocolVersion=%s sourceId=%s destinationId=%s namespace=%s data=%s',
-      message.protocol_version,
-      message.source_id,
-      message.destination_id,
+      message.protocolVersion,
+      message.sourceId,
+      message.destinationId,
       message.namespace,
-      (message.payload_type === 1) // BINARY
-        ? util.inspect(message.payload_binary)
-        : message.payload_utf8
+      (message.payloadType === 1) // BINARY
+        ? util.inspect(message.payloadBinary)
+        : message.payloadUtf8
     );
-    if(message.protocol_version !== 0) { // CASTV2_1_0
-      self.emit('error', new Error('Unsupported protocol version: ' + message.protocol_version));
+    if(message.protocolVersion !== 0) { // CASTV2_1_0
+      self.emit('error', new Error('Unsupported protocol version: ' + message.protocolVersion));
       self.close();
       return;
     }
 
     self.emit('message',
-      message.source_id,
-      message.destination_id,
+      message.sourceId,
+      message.destinationId,
       message.namespace,
-      (message.payload_type === 1) // BINARY
-        ? message.payload_binary 
-        : message.payload_utf8
+      (message.payloadType === 1) // BINARY
+        ? message.payloadBinary 
+        : message.payloadUtf8
     );    
   }
 
@@ -99,29 +99,29 @@ Client.prototype.close = function() {
 
 Client.prototype.send = function(sourceId, destinationId, namespace, data) {
   var message = {
-    protocol_version: 0, // CASTV2_1_0
-    source_id: sourceId,
-    destination_id: destinationId,
+    protocolVersion: 0, // CASTV2_1_0
+    sourceId: sourceId,
+    destinationId: destinationId,
     namespace: namespace
   };
 
   if(Buffer.isBuffer(data)) {
-    message.payload_type = 1 // BINARY;
-    message.payload_binary = data;
+    message.payloadType = 1 // BINARY;
+    message.payloadBinary = data;
   } else {
-    message.payload_type = 0 // STRING;
-    message.payload_utf8 = data;
+    message.payloadType = 0 // STRING;
+    message.payloadUtf8 = data;
   }
 
   debug(
     'send message: protocolVersion=%s sourceId=%s destinationId=%s namespace=%s data=%s',
-    message.protocol_version,
-    message.source_id,
-    message.destination_id,
+    message.protocolVersion,
+    message.sourceId,
+    message.destinationId,
     message.namespace,
-    (message.payload_type === 1) // BINARY
-      ? util.inspect(message.payload_binary)
-      : message.payload_utf8
+    (message.payloadType === 1) // BINARY
+      ? util.inspect(message.payloadBinary)
+      : message.payloadUtf8
   );
 
   var buf = CastMessage.serialize(message);

--- a/lib/server.js
+++ b/lib/server.js
@@ -51,16 +51,16 @@ Server.prototype.listen = function(port, host, callback) {
       debug(
         'recv message: clientId=%s protocolVersion=%s sourceId=%s destinationId=%s namespace=%s data=%s',
         clientId,
-        message.protocol_version,
-        message.source_id,
-        message.destination_id,
+        message.protocolVersion,
+        message.sourceId,
+        message.destinationId,
         message.namespace,
-        (message.payload_type === 1) // BINARY
-          ? util.inspect(message.payload_binary)
-          : message.payload_utf8
+        (message.payloadType === 1) // BINARY
+          ? util.inspect(message.payloadBinary)
+          : message.payloadUtf8
       );
 
-      if(message.protocol_version !== 0) { // CASTV2_1_0
+      if(message.protocolVersion !== 0) { // CASTV2_1_0
         debug('client error: clientId=%s unsupported protocol version (%s)', clientId, message.protocolVersion);
         var socket = self.clients[clientId].socket;
         socket.end();
@@ -69,12 +69,12 @@ Server.prototype.listen = function(port, host, callback) {
 
       self.emit('message',
         clientId,
-        message.source_id,
-        message.destination_id,
+        message.sourceId,
+        message.destinationId,
         message.namespace,
-        (message.payload_type === 1) // BINARY
-          ? message.payload_binary 
-          : message.payload_utf8
+        (message.payloadType === 1) // BINARY
+          ? message.payloadBinary 
+          : message.payloadUtf8
       );          
     }
 
@@ -113,30 +113,30 @@ Server.prototype.close = function() {
 
 Server.prototype.send = function(clientId, sourceId, destinationId, namespace, data) {
   var message = {
-    protocol_version: 0, // CASTV2_1_0
-    source_id: sourceId,
-    destination_id: destinationId,
+    protocolVersion: 0, // CASTV2_1_0
+    sourceId: sourceId,
+    destinationId: destinationId,
     namespace: namespace
   };
 
   if(Buffer.isBuffer(data)) {
-    message.payload_type = 1 // BINARY;
-    message.payload_binary = data;
+    message.payloadType = 1 // BINARY;
+    message.payloadBinary = data;
   } else {
-    message.payload_type = 0 // STRING;
-    message.payload_utf8 = data;
+    message.payloadType = 0 // STRING;
+    message.payloadUtf8 = data;
   }
 
   debug(
     'send message: clientId=%s protocolVersion=%s sourceId=%s destinationId=%s namespace=%s data=%s',
     clientId,
-    message.protocol_version,
-    message.source_id,
-    message.destination_id,
+    message.protocolVersion,
+    message.sourceId,
+    message.destinationId,
     message.namespace,
-    (message.payload_type === 1) // BINARY
-      ? util.inspect(message.payload_binary)
-      : message.payload_utf8
+    (message.payloadType === 1) // BINARY
+      ? util.inspect(message.payloadBinary)
+      : message.payloadUtf8
   );
 
   var buf = CastMessage.serialize(message);


### PR DESCRIPTION
I found protobuf now uses camelcase. You will want to utilize this version in v3 of multicast. I was unable to connect to a device without this change.